### PR TITLE
Fix Disable trash button when empty

### DIFF
--- a/app/components/BoardSidebar.tsx
+++ b/app/components/BoardSidebar.tsx
@@ -9,11 +9,13 @@ import {
 interface BoardSidebarProps {
   onAddItem: (type: string) => void;
   onDeleteAll: () => void;
+  isBoardEmpty: boolean;
 }
 
 export default function BoardSidebar({
   onAddItem,
   onDeleteAll,
+  isBoardEmpty
 }: BoardSidebarProps) {
   const sidebarItems = [
     { icon: <FileTextIcon size={16} />, label: "Note", type: "note" },
@@ -47,7 +49,10 @@ export default function BoardSidebar({
       <div className="mt-auto mb-4">
         <button
           onClick={onDeleteAll}
-          className="w-full px-2 py-1.5 flex flex-col items-center justify-center text-gray-600 hover:bg-gray-50 transition-colors text-xs"
+          disabled={isBoardEmpty}
+          className={`w-full px-2 py-1.5 flex flex-col items-center justify-center text-gray-600 ${
+            isBoardEmpty ? "opacity-50 cursor-not-allowed" : "hover:bg-gray-50"
+          } transition-colors text-xs`}
         >
           <div className="mb-1">
             <Trash2Icon size={16} />

--- a/app/dashboard/board/[id]/client.tsx
+++ b/app/dashboard/board/[id]/client.tsx
@@ -357,6 +357,13 @@ function Flow({ boardId }: { boardId: string }) {
       });
   }, [board, handleSaveToLocalStorage, nodes, edges, boardId, lastSaved?.localStorage]);
 
+  const [isBoardEmpty, setIsBoardEmpty] = useState(true);
+
+  // Update the board empty state whenever nodes or edges change
+  useEffect(() => {
+    setIsBoardEmpty(nodes.length === 0 && edges.length === 0);
+  }, [nodes, edges]);
+
   const handleDeleteAll = useCallback(() => {
     if (!board) return;
     
@@ -410,7 +417,7 @@ function Flow({ boardId }: { boardId: string }) {
   return (
     <div className="min-h-screen flex flex-col bg-gray-50">
       {/* Board Sidebar */}
-      <BoardSidebar onAddItem={addNewItem} onDeleteAll={handleDeleteAll} />
+      <BoardSidebar onAddItem={addNewItem} onDeleteAll={handleDeleteAll} isBoardEmpty={isBoardEmpty}/>
 
       {/* Main Content */}
       <div className="ml-16 h-screen">


### PR DESCRIPTION
## Description  
This PR disables the trash button when the board is empty. It improves the user experience by preventing users from clicking the button when there’s nothing to delete.  
